### PR TITLE
Gimbal and Camera controller refactor

### DIFF
--- a/DronePan.xcodeproj/project.pbxproj
+++ b/DronePan.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1583BF551CC26C2100C00C0D /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1583BF541CC26C2100C00C0D /* CameraController.swift */; };
+		1583BF571CC26F6E00C00C0D /* ControllerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1583BF561CC26F6E00C00C0D /* ControllerUtils.swift */; };
+		15F509FF1CC290F80097EB09 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F509FE1CC290F80097EB09 /* SettingsViewController.swift */; };
 		232F6F121C5448320013CCD9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 232F6F111C5448320013CCD9 /* main.m */; };
 		232F6F151C5448320013CCD9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 232F6F141C5448320013CCD9 /* AppDelegate.m */; };
 		232F6F181C5448320013CCD9 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 232F6F171C5448320013CCD9 /* ViewController.m */; };
@@ -38,6 +41,7 @@
 		23C5D0E01C91CBE30017F6F8 /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C5D0DF1C91CBE30017F6F8 /* Utils.m */; };
 		23C5D0E41C92359E0017F6F8 /* DJISDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 232F6F431C5449280013CCD9 /* DJISDK.framework */; };
 		23C5D0E51C92359E0017F6F8 /* DJISDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 232F6F431C5449280013CCD9 /* DJISDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4E1AD2718F84A81080EE0481 /* GimbalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1ADC2CAEC27E8366417603 /* GimbalController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +76,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1583BF541CC26C2100C00C0D /* CameraController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
+		1583BF561CC26F6E00C00C0D /* ControllerUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControllerUtils.swift; sourceTree = "<group>"; };
+		158ECBBF1CC0113400A2765F /* DronePan-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DronePan-Bridging-Header.h"; sourceTree = "<group>"; };
+		15F509FE1CC290F80097EB09 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		232F6F0D1C5448320013CCD9 /* DronePan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DronePan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		232F6F111C5448320013CCD9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		232F6F131C5448320013CCD9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -209,6 +217,7 @@
 		232F6FDF1C546E830013CCD9 /* MBProgressHUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBProgressHUD.m; sourceTree = "<group>"; };
 		23C5D0DE1C91CBE30017F6F8 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
 		23C5D0DF1C91CBE30017F6F8 /* Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Utils.m; sourceTree = "<group>"; };
+		4E1ADC2CAEC27E8366417603 /* GimbalController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GimbalController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -282,6 +291,7 @@
 			children = (
 				232F6F131C5448320013CCD9 /* AppDelegate.h */,
 				232F6F141C5448320013CCD9 /* AppDelegate.m */,
+				158ECBBF1CC0113400A2765F /* DronePan-Bridging-Header.h */,
 				232F6F1C1C5448320013CCD9 /* Assets.xcassets */,
 				232F6F431C5449280013CCD9 /* DJISDK.framework */,
 				232F6F211C5448320013CCD9 /* Info.plist */,
@@ -291,6 +301,10 @@
 				232F6FDF1C546E830013CCD9 /* MBProgressHUD.m */,
 				232F6F101C5448320013CCD9 /* Supporting Files */,
 				232F6F451C54493B0013CCD9 /* VideoPreviewer */,
+				1583BF541CC26C2100C00C0D /* CameraController.swift */,
+				4E1ADC2CAEC27E8366417603 /* GimbalController.swift */,
+				1583BF561CC26F6E00C00C0D /* ControllerUtils.swift */,
+				15F509FE1CC290F80097EB09 /* SettingsViewController.swift */,
 				232F6F161C5448320013CCD9 /* ViewController.h */,
 				232F6F171C5448320013CCD9 /* ViewController.m */,
 				23C5D0DE1C91CBE30017F6F8 /* Utils.h */,
@@ -712,14 +726,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				23C5D0E01C91CBE30017F6F8 /* Utils.m in Sources */,
+				1583BF571CC26F6E00C00C0D /* ControllerUtils.swift in Sources */,
 				232F6FD01C54493B0013CCD9 /* VideoFrameExtractor.m in Sources */,
 				232F6FCF1C54493B0013CCD9 /* MovieGLView.m in Sources */,
 				232F6F181C5448320013CCD9 /* ViewController.m in Sources */,
 				232F6F151C5448320013CCD9 /* AppDelegate.m in Sources */,
 				232F6F121C5448320013CCD9 /* main.m in Sources */,
+				1583BF551CC26C2100C00C0D /* CameraController.swift in Sources */,
 				232F6FC51C54493B0013CCD9 /* DJILinkQueues.m in Sources */,
 				232F6FD11C54493B0013CCD9 /* VideoPreviewer.m in Sources */,
+				15F509FF1CC290F80097EB09 /* SettingsViewController.swift in Sources */,
 				232F6FE01C546E830013CCD9 /* MBProgressHUD.m in Sources */,
+				4E1AD2718F84A81080EE0481 /* GimbalController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -876,6 +894,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.unmannedairlines.DronePan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "DronePan/DronePan-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -898,6 +917,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.unmannedairlines.DronePan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "DronePan/DronePan-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/DronePan/CameraController.swift
+++ b/DronePan/CameraController.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+import DJISDK
+
+@objc protocol CameraControllerDelegate {
+    func cameraControllerCompleted()
+
+    func cameraControllerAborted()
+
+    func cameraControllerReset()
+
+    func cameraReceivedVideo(videoBuffer: UnsafeMutablePointer<UInt8>, size: Int)
+}
+
+@objc class CameraController: NSObject, DJICameraDelegate {
+    let camera: DJICamera
+
+    var delegate: CameraControllerDelegate?
+
+    let maxCount = 5
+
+    let cameraWorkQueue = dispatch_queue_create("com.dronepan.queue.camera", DISPATCH_QUEUE_CONCURRENT)
+
+    var tookShot: Bool = false
+    var isShooting: Bool = false
+    var isStoring: Bool = false
+
+    var mode: DJICameraMode = .Unknown
+
+    init(camera: DJICamera) {
+        self.camera = camera
+
+        super.init()
+
+        camera.delegate = self
+    }
+
+    func setPhotoMode() {
+        dispatch_async(self.cameraWorkQueue) {
+            self.setPhotoMode(0)
+        }
+    }
+
+    func takeASnap() {
+        self.tookShot = false
+        dispatch_async(self.cameraWorkQueue) {
+            self.takeASnap(0)
+        }
+    }
+
+    private func setPhotoMode(counter: Int) {
+        if (counter > maxCount) {
+            self.delegate?.cameraControllerAborted()
+            return
+        }
+
+        let nextCount = counter + 1
+
+        self.camera.setCameraMode(.ShootPhoto) {
+            (error) in
+
+            if let e = error {
+                NSLog("Error setting photo mode: \(e)")
+
+                self.setPhotoMode(nextCount)
+            }
+        }
+
+        delay(2) {
+            if (self.mode == .ShootPhoto) {
+                self.delegate?.cameraControllerCompleted()
+            } else {
+                NSLog("Camera hasn't set mode yet count: \(counter)")
+
+                self.setPhotoMode(nextCount)
+            }
+        }
+    }
+
+    private func takeASnap(counter: Int) {
+        if (counter > maxCount) {
+            self.delegate?.cameraControllerAborted()
+            return
+        }
+
+        let nextCount = counter + 1
+
+        self.camera.startShootPhoto(.Single) {
+            (error) in
+            if let e = error {
+                NSLog("Error taking a photo: \(e)")
+
+                self.takeASnap(nextCount)
+            }
+        }
+
+        self.checkTakeASnap(0, counter: counter)
+    }
+
+    private func checkTakeASnap(checkCounter: Int, counter: Int) {
+        if (checkCounter > maxCount) {
+            self.delegate?.cameraControllerAborted()
+            return
+        }
+
+        delay(2) {
+            if (self.tookShot) {
+                self.delegate?.cameraControllerCompleted()
+            } else if (self.isShooting || self.isStoring) {
+                self.checkTakeASnap(checkCounter + 1, counter: counter)
+            } else {
+                NSLog("Camera hasn't taken shot yet count: \(counter)")
+
+                self.takeASnap(counter + 1)
+            }
+        }
+    }
+
+    private func delay(delay: Double, closure: () -> ()) {
+        ControllerUtils.delay(delay, queue: self.cameraWorkQueue, closure: closure)
+    }
+
+    func camera(camera: DJICamera, didReceiveVideoData videoBuffer: UnsafeMutablePointer<UInt8>, length size: Int) {
+        self.delegate?.cameraReceivedVideo(videoBuffer, size: size)
+    }
+
+    func camera(camera: DJICamera, didUpdateSystemState systemState: DJICameraSystemState) {
+        self.mode = systemState.mode
+
+        self.isShooting = systemState.isShootingSinglePhoto ||
+                systemState.isShootingSinglePhotoInRAWFormat ||
+                systemState.isShootingBurstPhoto ||
+                systemState.isShootingIntervalPhoto
+
+        self.isStoring = systemState.isStoringPhoto
+    }
+
+    func camera(camera: DJICamera, didGenerateNewMediaFile newMedia: DJIMedia) {
+        self.tookShot = true
+    }
+
+    func camera(camera: DJICamera, didGenerateTimeLapsePreview previewImage: UIImage) {
+        // Might be able to use this for progress later
+    }
+
+    func camera(camera: DJICamera, didUpdateSDCardState sdCardState: DJICameraSDCardState) {
+        // TODO - check full, error etc
+    }
+}

--- a/DronePan/ControllerUtils.swift
+++ b/DronePan/ControllerUtils.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class ControllerUtils {
+    class func delay(delay: Double, queue: dispatch_queue_t, closure: () -> ()) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delay * Double(NSEC_PER_SEC))),
+                queue,
+                closure)
+    }
+}

--- a/DronePan/DronePan-Bridging-Header.h
+++ b/DronePan/DronePan-Bridging-Header.h
@@ -1,4 +1,7 @@
-//
 //  Use this file to import your target's public headers that you would like to expose to Swift.
-//
 
+#ifndef DronePan_Bridging_Header_h
+#define DronePan_Bridging_Header_h
+
+
+#endif

--- a/DronePan/GimbalController.swift
+++ b/DronePan/GimbalController.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+import DJISDK
+
+@objc protocol GimbalControllerDelegate {
+    func gimbalControllerCompleted()
+
+    func gimbalControllerAborted()
+}
+
+@objc class GimbalController: NSObject, DJIGimbalDelegate {
+    let gimbal: DJIGimbal
+
+    var delegate: GimbalControllerDelegate?
+
+    let maxCount = 5
+    let allowedOffset: Float = 2.5
+
+    var currentPitch: Float = 0
+    var currentYaw: Float = 0
+    var currentRoll: Float = 0
+
+    var lastSetPitch: Float = 0
+    var lastSetYaw: Float = 0
+    var lastSetRoll: Float = 0
+
+    let isPitchAdjustable: Bool
+    let isYawAdjustable: Bool
+    let isRollAdjustable: Bool
+
+    let gimbalWorkQueue = dispatch_queue_create("com.dronepan.queue.gimbal", DISPATCH_QUEUE_CONCURRENT)
+
+    init(gimbal: DJIGimbal) {
+        self.gimbal = gimbal
+
+        if let constraints = gimbal.getGimbalConstraints() {
+            isPitchAdjustable = constraints.isPitchAdjustable
+            isYawAdjustable = constraints.isYawAdjustable
+            isRollAdjustable = constraints.isRollAdjustable
+        } else {
+            isPitchAdjustable = false
+            isYawAdjustable = false
+            isRollAdjustable = false
+        }
+
+        super.init()
+
+        gimbal.completionTimeForControlAngleAction = 0.5
+        gimbal.delegate = self
+    }
+
+    func reset() {
+        dispatch_async(self.gimbalWorkQueue) {
+            self.reset(0)
+        }
+    }
+
+    func setPitch(pitch: Float) {
+        let pitchInRange = self.gimbalAngleForHeading(pitch)
+        self.lastSetPitch = pitchInRange
+        dispatch_async(self.gimbalWorkQueue) {
+            self.setAttitude(0, pitch: pitchInRange, yaw: self.lastSetYaw, roll: self.lastSetRoll)
+        }
+    }
+
+    func setYaw(yaw: Float) {
+        let yawInRange = self.gimbalAngleForHeading(yaw)
+        self.lastSetYaw = yawInRange
+        dispatch_async(self.gimbalWorkQueue) {
+            self.setAttitude(0, pitch: self.lastSetPitch, yaw: yawInRange, roll: self.lastSetRoll)
+        }
+    }
+
+    func setRoll(roll: Float) {
+        let rollInRange = self.gimbalAngleForHeading(roll)
+        self.lastSetRoll = rollInRange
+        dispatch_async(self.gimbalWorkQueue) {
+            self.setAttitude(0, pitch: self.lastSetPitch, yaw: self.lastSetYaw, roll: rollInRange)
+        }
+    }
+
+    private func gimbalAngleForHeading(angle: Float) -> Float {
+        let sign = (angle == 0) ? 1 : angle / fabs(angle)
+
+        var angleInRange = angle * sign
+
+        while angleInRange > 360 {
+            angleInRange -= 360
+        }
+
+        if (angleInRange > 180) {
+            angleInRange = (360 - angleInRange) * -1.0
+        }
+
+        return angleInRange * sign
+    }
+
+    private func delay(delay: Double, closure: () -> ()) {
+        ControllerUtils.delay(delay, queue: self.gimbalWorkQueue, closure: closure)
+    }
+
+    private func valueInRange(adjustable: Bool, value: Float, currentValue: Float) -> Bool {
+        return !adjustable || ((value - allowedOffset) ... (value + allowedOffset) ~= currentValue)
+    }
+
+    private func check(pitch p: Float, yaw y: Float, roll r: Float) -> Bool {
+        return valueInRange(isPitchAdjustable, value: p, currentValue: self.currentPitch) &&
+                valueInRange(isYawAdjustable, value: y, currentValue: self.currentYaw) &&
+                valueInRange(isRollAdjustable, value: r, currentValue: self.currentRoll)
+    }
+
+    private func reset(counter: Int) {
+        self.lastSetPitch = 0
+        self.lastSetYaw = 0
+        self.lastSetRoll = 0
+
+        if (counter > maxCount) {
+            self.delegate?.gimbalControllerAborted()
+            return
+        }
+
+        let nextCount = counter + 1
+
+        self.gimbal.resetGimbalWithCompletion {
+            (error) in
+
+            if let e = error {
+                NSLog("Error resetting gimbal: \(e)")
+
+                self.reset(nextCount)
+            }
+        }
+
+        delay(gimbal.completionTimeForControlAngleAction + 0.5) {
+            if !self.check(pitch: 0, yaw: 0, roll: 0) {
+                NSLog("Gimbal not reset count: \(counter)")
+
+                self.reset(nextCount)
+            } else {
+                NSLog("Gimbal OK reset count: \(counter)")
+
+                self.delegate?.gimbalControllerCompleted()
+            }
+        }
+    }
+
+    private func setAttitude(counter: Int, pitch: Float, yaw: Float, roll: Float) {
+        NSLog("Setting attitude: count \(counter), pitch \(pitch), yaw \(yaw), roll \(roll)")
+
+        if (counter > maxCount) {
+            self.delegate?.gimbalControllerAborted()
+            return
+        }
+
+        let nextCount = counter + 1
+
+        // For aircraft gimbal positive values represent clockwise (upward) rotation and negative values represent
+        // counter clockwise (downward) rotation
+        // DJIGimbalRotateDirection pitchDir = pitch > 0 ? DJIGimbalRotateDirectionClockwise : DJIGimbalRotateDirectionCounterClockwise;
+        // Test if we need to set - since for the Osmo it just "did the right thing (tm)"
+
+        var pitchRotation = DJIGimbalAngleRotation()
+        var yawRotation = DJIGimbalAngleRotation()
+        var rollRotation = DJIGimbalAngleRotation()
+
+        pitchRotation.enabled = ObjCBool(isPitchAdjustable)
+        yawRotation.enabled = ObjCBool(isYawAdjustable)
+        rollRotation.enabled = ObjCBool(isRollAdjustable)
+
+        if (isPitchAdjustable) {
+            pitchRotation.angle = pitch
+        }
+
+        if (isYawAdjustable) {
+            yawRotation.angle = yaw
+        }
+
+        if (isRollAdjustable) {
+            rollRotation.angle = roll
+        }
+
+        gimbal.rotateGimbalWithAngleMode(.AngleModeAbsoluteAngle, pitch: pitchRotation, roll: rollRotation, yaw: yawRotation, withCompletion: {
+            (error) in
+
+            if let e = error {
+                NSLog("Error setting attitude on gimbal: \(e)")
+
+                self.setAttitude(nextCount, pitch: pitch, yaw: yaw, roll: roll)
+            }
+        })
+
+        delay(gimbal.completionTimeForControlAngleAction + 0.5) {
+            if !self.check(pitch: pitch, yaw: yaw, roll: roll) {
+                NSLog("Gimbal attitude not set count: \(counter)")
+
+                self.setAttitude(nextCount, pitch: pitch, yaw: yaw, roll: roll)
+            } else {
+                self.delegate?.gimbalControllerCompleted()
+            }
+        }
+    }
+
+    func gimbalController(controller: DJIGimbal, didUpdateGimbalState gimbalState: DJIGimbalState) {
+        let atti = gimbalState.attitudeInDegrees
+
+        self.currentPitch = atti.pitch
+        self.currentYaw = atti.yaw
+        self.currentRoll = atti.roll
+    }
+}

--- a/DronePan/ViewController.m
+++ b/DronePan/ViewController.m
@@ -12,33 +12,39 @@
 #import "MBProgressHUD.h"
 #import "Utils.h"
 
+#import "DronePan-Swift.h"
+
 #define ENABLE_DEBUG_MODE 0
 
 #define STANDARD_DELAY 3
 
-@interface ViewController () <DJICameraDelegate, DJISDKManagerDelegate, DJIFlightControllerDelegate, DJIGimbalDelegate> {
+@interface ViewController () <DJISDKManagerDelegate, DJIFlightControllerDelegate, GimbalControllerDelegate, CameraControllerDelegate> {
     dispatch_queue_t droneCmdsQueue;
 }
 
-@property(nonatomic, strong) DJICamera *camera;
+@property(nonatomic, weak) DJIBaseProduct *product;
+
 @property(weak, nonatomic) IBOutlet UIView *cameraView;
 @property(weak, nonatomic) IBOutlet UIButton *startButton;
-@property(nonatomic, weak) DJIBaseProduct *product;
 @property(weak, nonatomic) IBOutlet UILabel *connectionStatusLabel;
 @property(weak, nonatomic) IBOutlet UILabel *headingLabel;
 @property(weak, nonatomic) IBOutlet UILabel *sequenceLabel;
+
 @property(nonatomic, assign) long sequenceCount;
 @property(nonatomic, assign) long currentCount;
 @property(nonatomic, assign) double currentHeading;
 @property(nonatomic, assign) double yawSpeed;
 @property(nonatomic, assign) double yawDestination;
-@property(nonatomic, assign) float gimbalPitchDestination;
-@property(nonatomic, assign) float currentGimbalPitch;
 @property(nonatomic, assign) NSTimer *yawTimer;
 @property(nonatomic, assign) CLLocationCoordinate2D aircraftLocation;
 @property(nonatomic, assign) float aircraftAltitude;
 
-@property (weak, nonatomic) IBOutlet UITextView *debugTextView;
+@property(nonatomic, strong) GimbalController *gimbalController;
+@property(nonatomic, strong) dispatch_group_t gimbalDispatchGroup;
+@property(nonatomic, strong) CameraController *cameraController;
+@property(nonatomic, strong) dispatch_group_t cameraDispatchGroup;
+
+@property(weak, nonatomic) IBOutlet UITextView *debugTextView;
 
 - (IBAction)startPano:(id)sender;
 
@@ -59,18 +65,20 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    
+
     NSString *appKey = @"d6b78c9337f72fadd85d88e2";
     [DJISDKManager registerApp:appKey withDelegate:self];
 }
 
 // Hide status bar
--(BOOL)prefersStatusBarHidden{
+- (BOOL)prefersStatusBarHidden {
     return YES;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.gimbalDispatchGroup = dispatch_group_create();
+    self.cameraDispatchGroup = dispatch_group_create();
 }
 
 - (void)didReceiveMemoryWarning {
@@ -79,30 +87,30 @@
 
 // Let's detect the aircraft and then start the sequence
 - (IBAction)startPano:(id)sender {
-    
+
     // Check to see if a pano is in progress
     NSString *label = self.startButton.currentTitle;
-    if([label isEqualToString:@"Stop"]) {
+    if ([label isEqualToString:@"Stop"]) {
         NSLog(@"Let's stop the pano");
         return;
     }
-    
+
     [Utils displayToastOnApp:@"Starting pano"];
-    
+
     // Change the button text to stop
-    [self.startButton setTitle: @"Stop" forState: UIControlStateNormal];
-    
+    [self.startButton setTitle:@"Stop" forState:UIControlStateNormal];
+
     NSString *model = self.product.model;
-    
+
     // Display the aircract model we're connected to
     [self.connectionStatusLabel setText:model];
-    
+
     if ([self productType] == PT_AIRCRAFT) {
         /* add if logic for I1 and P3
          here we would do aircraft yaw for P3 and give I1 users the option */
-        
+
         DJIFlightController *fc = [self fetchFlightController];
-         
+
         if (fc) {
             [fc enableVirtualStickControlModeWithCompletion:^(NSError *error) {
                 if (error) {
@@ -112,237 +120,135 @@
                     fc.yawControlMode = DJIVirtualStickYawControlModeAngularVelocity;
                     fc.rollPitchControlMode = DJIVirtualStickRollPitchControlModeVelocity;
                     fc.verticalControlMode = DJIVirtualStickVerticalControlModeVelocity;
-         
+
                     [self doPanoLoop];
                 }
             }];
-         
-         } else {
-             // Do something or nothing here
-             return;
-         }
-        
+
+        } else {
+            // Do something or nothing here
+            return;
+        }
+
     } else {
         [self doPanoLoop];
     }
-    
+
 }
 
 - (void)updateSequenceLabel {
     [[self sequenceLabel] setText:[NSString stringWithFormat:@"Sequence: %ld/%ld", self.currentCount, self.sequenceCount]];
 }
 
-// This is a test method to isolate yaw with no other commands - we can pull it out later
-/*
--(void)doPanoLoop3 {
-    
-    int PHOTOS_PER_ROW = 6;
-    
-    NSArray *yaw = [self yawAnglesForCount:PHOTOS_PER_ROW withHeading:[self headingTo360:self.currentHeading]];
-    
-    droneCmdsQueue = dispatch_queue_create("com.dronepan.queue", DISPATCH_QUEUE_SERIAL);
-    
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-       
-        for (NSNumber *nYaw in yaw) {
-            
-            self.yawSpeed = 30; // This represents 30m/sec
-            self.yawDestination = [nYaw floatValue];
-            
-            NSLog(@"*******************");
-            NSLog(@"Starting loop with yawSpeed: %f and yawDestination: %f", self.yawSpeed, self.yawDestination);
-            NSLog(@"*******************");
-            
-            // Calling this on a timer as it improves the accuracy of aircraft yaw
-            dispatch_sync(droneCmdsQueue, ^{
-                NSTimer* sendTimer =[NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(yawAircraftUsingVelocity:) userInfo:nil repeats:YES];
-                [[NSRunLoop currentRunLoop]addTimer:sendTimer forMode:NSDefaultRunLoopMode];
-                [[NSRunLoop currentRunLoop]runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]];
-                [sendTimer invalidate];
-                sendTimer=nil;
-            });
-            
-            
-            // Delay
-            dispatch_sync(droneCmdsQueue, ^{
-                [self waitFor:STANDARD_DELAY];
-            });
-            
-        }
-        
-    });
-}
- */
-
 - (void)doPanoLoop {
-    
+
     NSArray *pitchAircraftYaw = @[@0, @-30, @-60];
-    
+
     NSArray *pitchOsmo = @[@-60, @-30, @0, @30];
-    
+
     NSArray *pitch;
-    
+
     int PHOTOS_PER_ROW = 6; // Make this a setting
-    
+
     NSArray *yaw = [self yawAnglesForCount:PHOTOS_PER_ROW withHeading:[self headingTo360:self.currentHeading]];
-    
+
     if ([self productType] == PT_AIRCRAFT) {
         pitch = pitchAircraftYaw;
     } else if ([self productType] == PT_HANDHELD) {
         pitch = pitchOsmo;
     } else {
         NSLog(@"Pano started with unknown type");
-        
+
         return;
     }
-    
-    // Make pitching gimbal fast so we have time to shoot
-    [self fetchGimbal].completionTimeForControlAngleAction = 0.5;
-    
+
     self.sequenceCount = ([pitch count] * [yaw count]) + 1;
     self.currentCount = 0;
-    
+
     [self updateSequenceLabel];
-    
+
     droneCmdsQueue = dispatch_queue_create("com.dronepan.queue", DISPATCH_QUEUE_SERIAL);
-    
+
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        
+
         // Set camera mode
-        dispatch_sync(droneCmdsQueue, ^{
-            [self setPhotoMode];
-        });
-        
+        [self setPhotoMode];
+
         // Reset gimbal - this will reset the gimbal yaw in case the user has changed it outside of DronePan
-        dispatch_sync(droneCmdsQueue, ^{
-            [self resetGimbal];
-        });
-        
-        // Short delay - allow you to get out of shot - should be GUI choice/display
-        [self waitFor:5];
-        
+        [self resetGimbal];
+
         // We yaw the aircraft to its destination
         // For now we'll pitch gimbal back to 0 and restart the sequence
         // An improvement may be to move the gimbal in a "sawtooth" manner
         for (NSNumber *nYaw in yaw) {
-            
+
             // Loop through the gimbal pitches
             for (NSNumber *nPitch in pitch) {
-            
-                self.gimbalPitchDestination = [nPitch floatValue];
-                
-                // Pitch the gimbal
-                dispatch_sync(droneCmdsQueue, ^{
-                    [self setPitch:[nPitch floatValue]];
-                });
-                
-                // Delay
-                dispatch_sync(droneCmdsQueue, ^{
-                    [self waitFor:STANDARD_DELAY];
-                });
-                
-                // Take the photo
-                dispatch_sync(droneCmdsQueue, ^{
-                    [self takeASnap];
-                });
-                
-                // Delay
-                dispatch_sync(droneCmdsQueue, ^{
-                    [self waitFor:STANDARD_DELAY];
-                });
-                
+                [self setPitch:[nPitch floatValue]];
+                [self takeASnap];
             } // End the gimbal pitch loop
-            
+
             // Now we yaw after a column of photos has been taken
             if ([self productType] == PT_AIRCRAFT) {
-                
+
                 self.yawSpeed = 30; // This represents 25m/sec
                 self.yawDestination = [nYaw floatValue];
-                
+
                 // Calling this on a timer as it improves the accuracy of aircraft yaw
                 dispatch_sync(droneCmdsQueue, ^{
-                    NSTimer* sendTimer =[NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(yawAircraftUsingVelocity:) userInfo:nil repeats:YES];
-                    [[NSRunLoop currentRunLoop]addTimer:sendTimer forMode:NSDefaultRunLoopMode];
-                    [[NSRunLoop currentRunLoop]runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]];
+                    NSTimer *sendTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(yawAircraftUsingVelocity:) userInfo:nil repeats:YES];
+                    [[NSRunLoop currentRunLoop] addTimer:sendTimer forMode:NSDefaultRunLoopMode];
+                    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]];
                     [sendTimer invalidate];
-                    sendTimer=nil;
+                    sendTimer = nil;
                 });
-                
+
             } else if ([self productType] == PT_HANDHELD) {
-                dispatch_sync(droneCmdsQueue, ^{
-                    [self setYaw:[nYaw floatValue]];
-                });
+                [self setYaw:[nYaw floatValue]];
             }
-            
-            // Adding delay after yaw
-            dispatch_sync(droneCmdsQueue, ^{
-                [self waitFor:STANDARD_DELAY];
-            });
-            
-            
         } // End yaw loop
-        
+
         // Take the final zenith/nadir shot and then reset the gimbal back
-        dispatch_sync(droneCmdsQueue, ^{
-            self.gimbalPitchDestination = -90.0;
-            [self setPitch:self.gimbalPitchDestination];
-        });
-        
-        // Delay before we take the final photo
-        dispatch_sync(droneCmdsQueue, ^{
-            [self waitFor:STANDARD_DELAY];
-        });
-        
-        dispatch_sync(droneCmdsQueue, ^{
-            [self takeASnap];
-        });
-        
-        // Delay before we reset the gimbal back to the horizon
-        dispatch_sync(droneCmdsQueue, ^{
-            [self waitFor:STANDARD_DELAY];
-        });
-        
-        dispatch_sync(droneCmdsQueue, ^{
-            self.gimbalPitchDestination = 0;
-            [self setPitch:self.gimbalPitchDestination];
-        });
-        
+        [self setPitch:(float) -90.0];
+        [self takeASnap];
+        [self resetGimbal];
+
         dispatch_async(dispatch_get_main_queue(), ^{
             [[self sequenceLabel] setText:@"Sequence: Done"];
         });
-        
+
         dispatch_async(dispatch_get_main_queue(), ^{
             [Utils displayToastOnApp:@"Completed pano"];
-            [self.startButton setTitle: @"Start" forState: UIControlStateNormal];
+            [self.startButton setTitle:@"Start" forState:UIControlStateNormal];
         });
-        
+
     }); // End GCD
-    
+
 }
 
-- (NSArray *)yawAnglesForCount:(int)count withHeading:(double) heading {
+- (NSArray *)yawAnglesForCount:(int)count withHeading:(double)heading {
     // We must ensure that valid PHOTOS_PER_ROW in settings is a divisor of 360
-    int YAW_ANGLE = 360/count;
-    
+    int YAW_ANGLE = 360 / count;
+
     NSMutableArray *yaw = [[NSMutableArray alloc] init];
-    
+
     // Here we loop and create yaw angles based off the current aircraft heading
     // When a users clicks the start button that will be the point of reference from
     // Which we build the entire array of yaw angles
-    for(int i=0; i<count; i++) {
-        double destinationAngle = heading + (YAW_ANGLE*(i+1)); // The +1 makes sure the first destination is not the current heading
-        
-        if(destinationAngle > 360)
+    for (int i = 0; i < count; i++) {
+        double destinationAngle = heading + (YAW_ANGLE * (i + 1)); // The +1 makes sure the first destination is not the current heading
+
+        if (destinationAngle > 360)
             destinationAngle = destinationAngle - 360;
-        
-        [yaw addObject:[NSNumber numberWithDouble: destinationAngle]];
-        
-        NSString *debug = [NSString stringWithFormat: @"%@degrees: %f\n", self.debugTextView.text, destinationAngle];
-        [self.debugTextView setText: debug];
-        
+
+        [yaw addObject:@(destinationAngle)];
+
+        NSString *debug = [NSString stringWithFormat:@"%@degrees: %f\n", self.debugTextView.text, destinationAngle];
+        [self.debugTextView setText:debug];
+
         NSLog(@"angle: %f\n", destinationAngle);
     }
-    
+
     return yaw;
 }
 
@@ -356,30 +262,19 @@
 
 #pragma mark GCD functions
 
-- (void)resetGimbal {
-    DJIGimbal *gimbal = [self fetchGimbal];
-    
-    if (gimbal) {
-        [gimbal resetGimbalWithCompletion:^(NSError *_Nullable error) {
-            if (error) {
-                NSLog(@"Error resetting gimbal: %@", error);
-            }
-            
-            [self waitFor:STANDARD_DELAY];
-        }];
+- (void)setPhotoMode {
+    if (self.cameraController) {
+        dispatch_group_enter(self.cameraDispatchGroup);
+        [self.cameraController setPhotoMode];
+        dispatch_group_wait(self.cameraDispatchGroup, DISPATCH_TIME_FOREVER);
     }
 }
 
-- (void)setPhotoMode {
-    DJICamera *camera = [self fetchCamera];
-    
-    if (camera) {
-        [camera setCameraMode:DJICameraModeShootPhoto withCompletion:^(NSError *_Nullable error) {
-            if (error) {
-                [Utils displayToastOnApp:@"Couldn't set camera to photo mode"];
-                NSLog(@"Unable to set camera to photo mode: %@", error);
-            }
-        }];
+- (void)takeASnap {
+    if (self.cameraController) {
+        dispatch_group_enter(self.cameraDispatchGroup);
+        [self.cameraController takeASnap];
+        dispatch_group_wait(self.cameraDispatchGroup, DISPATCH_TIME_FOREVER);
     }
 }
 
@@ -389,114 +284,59 @@
 }
 
 - (void)yawAircraft:(NSTimer *)timer {
-    
+
     NSDictionary *data = [timer userInfo];
-    
+
     DJIVirtualStickFlightControlData ctrlData = {0};
     ctrlData.pitch = 0;
     ctrlData.roll = 0;
     ctrlData.verticalThrottle = 0;
-    ctrlData.yaw = [[data objectForKey: @"yaw"] floatValue];
-    
+    ctrlData.yaw = [data[@"yaw"] floatValue];
+
     DJIFlightController *fc = [self fetchFlightController];
-    
+
     if (fc && fc.isVirtualStickControlModeAvailable) {
         [fc sendVirtualStickFlightControlData:ctrlData withCompletion:nil];
     }
 }
 
 - (void)yawAircraftUsingVelocity:(NSTimer *)timer {
-    
+
     DJIVirtualStickFlightControlData ctrlData = {0};
     ctrlData.pitch = 0;
     ctrlData.roll = 0;
     ctrlData.verticalThrottle = 0;
-    ctrlData.yaw = self.yawSpeed;
-    
+    ctrlData.yaw = (float) self.yawSpeed;
+
     DJIFlightController *fc = [self fetchFlightController];
-    
+
     if (fc && fc.isVirtualStickControlModeAvailable) {
         [fc sendVirtualStickFlightControlData:ctrlData withCompletion:nil];
     }
 }
 
-- (void)takeASnap {
-
-    DJICamera *camera = [self fetchCamera];
-    
-    if (camera) {
-        [camera startShootPhoto:DJICameraShootPhotoModeSingle withCompletion:^(NSError *_Nullable error) {
-            if (error) {
-                [Utils displayToastOnApp:@"Error taking photo"];
-                NSLog(@"Unable to take image %@", error);
-            } else {
-                self.currentCount++;
-                [self updateSequenceLabel];
-            }
-            
-            [self waitFor:STANDARD_DELAY];
-        }];
-    }
-}
-
-- (void)setYaw:(DJIGimbalAngleRotation)yaw pitch:(DJIGimbalAngleRotation)pitch {
-    
-    DJIGimbal *gimbal = [self fetchGimbal];
-    
-    if (gimbal) {
-        DJIGimbalAngleRotation roll = {};
-        roll.enabled = NO;
-        
-        [gimbal rotateGimbalWithAngleMode:DJIGimbalAngleModeAbsoluteAngle pitch:pitch roll:roll yaw:yaw withCompletion:^(NSError *_Nullable error) {
-            if (error) {
-                if (yaw.enabled) {
-                    NSLog(@"Unable to yaw to yaw: %f,  %@", yaw.angle, error);
-                }
-                if (pitch.enabled) {
-                    NSLog(@"Unable to pitch to pitch: %f,  %@", pitch.angle, error);
-                }
-            }
-            
-            [self waitFor:STANDARD_DELAY];
-            
-        }];
+- (void)resetGimbal {
+    if (self.gimbalController) {
+        dispatch_group_enter(self.gimbalDispatchGroup);
+        [self.gimbalController reset];
+        dispatch_group_wait(self.gimbalDispatchGroup, DISPATCH_TIME_FOREVER);
     }
 }
 
 - (void)setYaw:(float)yaw {
-    DJIGimbalAngleRotation yawR, pitchR = {};
-    yawR.angle = yaw;
-    yawR.enabled = YES;
-    pitchR.enabled = NO;
-    
-    [self setYaw:yawR pitch:pitchR];
+    if (self.gimbalController) {
+        dispatch_group_enter(self.gimbalDispatchGroup);
+        [self.gimbalController setYaw:yaw];
+        dispatch_group_wait(self.gimbalDispatchGroup, DISPATCH_TIME_FOREVER);
+    }
 }
 
 - (void)setPitch:(float)pitch {
-    
-    // For aircraft gimbal positive values represent clockwise (upward) rotation and negative values represent counter clockwise (downward) rotation
-    DJIGimbalRotateDirection pitchDir = pitch > 0 ? DJIGimbalRotateDirectionClockwise : DJIGimbalRotateDirectionCounterClockwise;
-    DJIGimbalAngleRotation yawR, pitchR = {};
-    yawR.enabled = NO;
-    pitchR.enabled = YES;
-    pitchR.angle = pitch;
-    pitchR.direction = pitchDir;
-    
-    [self setYaw:yawR pitch:pitchR];
-    
-    // Let's delay for 2 seconds and then check to see if the gimbal has moved to the destination
-    // if it hasn't then let's retry setting the gimbal pitch
-    double delayInSeconds = 2.0;
-    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
-    dispatch_after(delay, dispatch_get_main_queue(), ^(void){
-        if(self.currentGimbalPitch > (self.gimbalPitchDestination-2.5) && self.currentGimbalPitch < (self.gimbalPitchDestination+2.5)) {
-            //NSLog(@"Gimbal pitch in correct position");
-        } else {
-            NSLog(@"Gimbal not in correct position. Let's check photo #%ld", self.currentCount);
-            [self setPitch: self.gimbalPitchDestination];
-        }
-    });
-    
+    if (self.gimbalController) {
+        dispatch_group_enter(self.gimbalDispatchGroup);
+        [self.gimbalController setPitch:pitch];
+        dispatch_group_wait(self.gimbalDispatchGroup, DISPATCH_TIME_FOREVER);
+    }
 }
 
 - (IBAction)launchSettingsView:(id)sender {
@@ -505,12 +345,63 @@
     [self presentViewController:settings animated:YES completion:nil];
 }
 
-#pragma mark - DJICameraDelegate
+#pragma mark - GimbalControllerDelegate
 
-- (void)camera:(DJICamera *)camera didReceiveVideoData:(uint8_t *)videoBuffer length:(size_t)size {
+- (void)gimbalControllerCompleted {
+    NSLog(@"Gimbal signalled complete");
+
+    dispatch_async(droneCmdsQueue, ^{
+        dispatch_group_leave(self.gimbalDispatchGroup);
+    });
+}
+
+- (void)gimbalControllerAborted {
+    // TODO - STOP THE PANO
+
+    NSLog(@"Gimbal signalled abort");
+
+    dispatch_async(droneCmdsQueue, ^{
+        dispatch_group_leave(self.gimbalDispatchGroup);
+    });
+}
+
+#pragma mark - CameraControllerDelegate
+
+- (void)cameraReceivedVideo:(uint8_t *)videoBuffer size:(NSInteger)size {
     uint8_t *pBuffer = (uint8_t *) malloc(size);
     memcpy(pBuffer, videoBuffer, size);
     [[VideoPreviewer instance].dataQueue push:pBuffer length:(int) size];
+}
+
+- (void)cameraControllerReset {
+    NSLog(@"Camera signalled reset");
+    
+    dispatch_async(droneCmdsQueue, ^{
+        dispatch_group_leave(self.cameraDispatchGroup);
+    });
+}
+
+- (void)cameraControllerCompleted {
+    NSLog(@"Camera signalled complete");
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.currentCount = self.currentCount + 1;
+        [self updateSequenceLabel];
+    });
+    
+    dispatch_async(droneCmdsQueue, ^{
+        dispatch_group_leave(self.cameraDispatchGroup);
+    });
+}
+
+- (void)cameraControllerAborted {
+    // TODO - STOP THE PANO
+
+    NSLog(@"Camera signalled abort");
+    
+    dispatch_async(droneCmdsQueue, ^{
+        dispatch_group_leave(self.cameraDispatchGroup);
+    });
 }
 
 #pragma mark Hardware helper methods
@@ -523,7 +414,7 @@ typedef enum {
 
 - (ProductType)productType {
     ProductType pt = PT_UNKNOWN;
-    
+
     if (!self.product) {
         NSLog(@"Didn't find product");
     } else {
@@ -533,44 +424,18 @@ typedef enum {
             pt = PT_HANDHELD;
         }
     }
-    
+
     return pt;
 }
 
-- (DJICamera *)fetchCamera {
-    
-    ProductType pt = [self productType];
-    
-    if (pt == PT_AIRCRAFT) {
-        return ((DJIAircraft *) self.product).camera;
-    } else if (pt == PT_HANDHELD) {
-        return ((DJIHandheld *) self.product).camera;
-    }
-    
-    return nil;
-}
-
 - (DJIFlightController *)fetchFlightController {
-    
+
     ProductType pt = [self productType];
-    
+
     if (pt == PT_AIRCRAFT) {
         return ((DJIAircraft *) self.product).flightController;
     }
-    
-    return nil;
-}
 
-- (DJIGimbal *)fetchGimbal {
-    
-    ProductType pt = [self productType];
-    
-    if (pt == PT_AIRCRAFT) {
-        return ((DJIAircraft *) self.product).gimbal;
-    } else if (pt == PT_HANDHELD) {
-        return ((DJIHandheld *) self.product).gimbal;
-    }
-    
     return nil;
 }
 
@@ -578,54 +443,64 @@ typedef enum {
 
 // Called from startConnectionToProduct
 - (void)sdkManagerProductDidChangeFrom:(DJIBaseProduct *_Nullable)oldProduct to:(DJIBaseProduct *_Nullable)newProduct {
-    
+
     if (newProduct) {
         NSLog(@"New product");
         self.product = newProduct;
-        
+
         [self.connectionStatusLabel setText:newProduct.model];
-        
-        __weak DJICamera *camera = [self fetchCamera];
-        
-        if (camera) {
-            [camera setDelegate:self];
-        }
-        
+
         // Set the flight controller delegate only with aircraft. Ignore for Osmo.
         if ([self productType] == PT_AIRCRAFT) {
             // Setup delegate so we can get fc and compass updates
             DJIFlightController *fc = [self fetchFlightController];
-            
+
             if (fc) {
                 [fc setDelegate:self];
             }
         }
-        
-        // Setup the gimbal delegate because the gimbal tends to ignore commands from time to time
-        // We want to verify the gimbal pitch before we shoot
-        DJIGimbal *gimbal = [self fetchGimbal];
-        
-        if(gimbal) {
-            [gimbal setDelegate:self];
+
+        ProductType pt = [self productType];
+
+        DJIGimbal *gimbal;
+        DJICamera *camera;
+
+        if (pt == PT_AIRCRAFT) {
+            camera = ((DJIAircraft *) self.product).camera;
+            gimbal = ((DJIAircraft *) self.product).gimbal;
+        } else if (pt == PT_HANDHELD) {
+            camera = ((DJIHandheld *) self.product).camera;
+            gimbal = ((DJIHandheld *) self.product).gimbal;
         }
-        
+
+        if (camera) {
+            self.cameraController = [[CameraController alloc] initWithCamera:camera];
+            self.cameraController.delegate = self;
+        }
+
+        if (gimbal) {
+            self.gimbalController = [[GimbalController alloc] initWithGimbal:gimbal];
+            self.gimbalController.delegate = self;
+        }
     } else {
         // Disconnected - let's update status label here
         [self.connectionStatusLabel setText:@"Disconnected"];
-        
+
         NSLog(@"Product disconnected");
-        
+
         self.product = nil;
+        self.cameraController = nil;
+        self.gimbalController = nil;
     }
 }
 
 - (void)sdkManagerDidRegisterAppWithError:(NSError *)error {
-    
+
     if (error) {
         NSString *msg = [NSString stringWithFormat:@"%@", error.description];
         [Utils displayToastOnApp:msg];
     } else {
-        
+
 #if ENABLE_DEBUG_MODE
         [DJISDKManager enterDebugModeWithDebugId:@"10.0.1.18"];
 #else
@@ -633,40 +508,34 @@ typedef enum {
         [DJISDKManager startConnectionToProduct];
 #endif
         [[VideoPreviewer instance] start];
-        
+
     }
-    
+
     //[self showAlertViewWithTitle:@"Register App" withMessage:message];
 }
 
 #pragma mark DJIFlightControllerDelegate Methods
 
 - (void)flightController:(DJIFlightController *)fc didUpdateSystemState:(DJIFlightControllerCurrentState *)state {
-    
+
     self.aircraftLocation = state.aircraftLocation;
-    
+
     self.aircraftAltitude = state.altitude;
-    
+
     self.currentHeading = [self headingTo360:fc.compass.heading];
-    
+
     self.headingLabel.text = [NSString stringWithFormat:@"Heading: %0.1f, %0.1f", self.currentHeading, self.yawDestination];
-    
+
     double diff;
-    
-    if(self.yawDestination > self.currentHeading) {
+
+    if (self.yawDestination > self.currentHeading) {
         diff = fabs(self.yawDestination) - fabs(self.currentHeading);
         self.yawSpeed = diff * 0.5;
     } else { // This happens when the current heading is 340 and destination is 40, for example
         diff = fabs(self.currentHeading) - fabs(self.yawDestination);
-        self.yawSpeed = fmod(360.0,diff)*0.5;
+        self.yawSpeed = fmod(360.0, diff) * 0.5;
     }
 
-}
-
-#pragma mark DJIGimbalDelegate Methods
-- (void)gimbalController:(DJIGimbal *)controller didUpdateGimbalState:(DJIGimbalState *)gimbalState {
-    DJIGimbalAttitude atti = gimbalState.attitudeInDegrees;
-    self.currentGimbalPitch = atti.pitch;
 }
 
 @end


### PR DESCRIPTION
All timeouts for gimbal and controller are now based on retries and delegates. 5 retries will cause an abort delegate method to call back to the ViewController. This needs to do a Stop pPano and message user - but is not written yet (write it as part of implementing Stop Pano").

This works fine on an Osmo.

Gimbal:

I have seen both moves that work and moves that cause a retry (since they took a little longer) and they also work.

Camera shots

It will take a shot - and wait for both shooting and storing to complete and also waits to be told that a new media file has been generated. Have only seen it waiting for store or shooting - not shot to be taken (haven't had the bug that it didn't take the shot - just that it took a while to take and store).

But - I believe this to be the correct approach. Any changes required for fixing any AC yaw issues should be added on top I think.

I feel that this really is adding stability - we're checking delegates for moves, photos, changing mode - all feels good to me :)
