### PR TITLE
Fixes #48. Relative gimbal yaw for P4 and I1

### DIFF
--- a/DronePan/Controllers/PanoramaController.swift
+++ b/DronePan/Controllers/PanoramaController.swift
@@ -625,7 +625,7 @@ extension PanoramaController: FlightControllerDelegate {
 extension PanoramaController: GimbalControllerDelegate {
     func setGimbal(gimbal: DJIGimbal?) {
         if let gimbal = gimbal {
-            self.gimbalController = GimbalController(gimbal: gimbal, supportsSDKYaw: ControllerUtils.supportsSDKYaw(self.model))
+            self.gimbalController = GimbalController(gimbal: gimbal, gimbalYawIsRelativeToAircraft: ControllerUtils.gimbalYawIsRelativeToAircraft(self.model))
             self.gimbalController!.delegate = self
         } else {
             self.gimbalController = nil

--- a/DronePan/Utils/ControllerUtils.swift
+++ b/DronePan/Utils/ControllerUtils.swift
@@ -62,10 +62,9 @@ class ControllerUtils {
         return ControllerUtils.isPhantom3(model) || ControllerUtils.isPhantom4(model)
     }
 
-    // TODO: this should be P4 only - https://github.com/dbaldwin/DronePan/issues/48
-    class func supportsSDKYaw(model: String?) -> Bool {
+    class func gimbalYawIsRelativeToAircraft(model: String?) -> Bool {
         if let model = model {
-            return !(ControllerUtils.isPhantom4(model) || ControllerUtils.isInspire(model))
+            return ControllerUtils.isPhantom4(model) || ControllerUtils.isInspire(model)
         } else {
             return false
         }

--- a/DronePanTests/CameraControllerTests.swift
+++ b/DronePanTests/CameraControllerTests.swift
@@ -590,7 +590,7 @@ class CameraControllerTests: XCTestCase {
 
         controller.takeASnap()
 
-        waitForExpectationsWithTimeout(13) {
+        waitForExpectationsWithTimeout(15) {
             error in
             if let error = error {
                 XCTFail("waitForExpectationsWithTimeout errored: \(error)")

--- a/DronePanTests/ControllerUtilsTests.swift
+++ b/DronePanTests/ControllerUtilsTests.swift
@@ -78,22 +78,22 @@ class ControllerUtilsTests: XCTestCase {
         XCTAssertTrue(ControllerUtils.isPhantom(DJIAircraftModelNamePhantom34K), "\(DJIAircraftModelNamePhantom34K) was not phantom")
     }
 
-    func testSupporsSDKYaw() {
-        XCTAssertFalse(ControllerUtils.supportsSDKYaw(DJIAircraftModelNameInspire1), "\(DJIAircraftModelNameInspire1) supports SDK yaw")
-        XCTAssertFalse(ControllerUtils.supportsSDKYaw(DJIAircraftModelNameInspire1RAW), "\(DJIAircraftModelNameInspire1RAW) supports SDK yaw")
-        XCTAssertFalse(ControllerUtils.supportsSDKYaw(DJIAircraftModelNameInspire1Pro), "\(DJIAircraftModelNameInspire1Pro) supports SDK yaw")
+    func testGimbalYawIsRelativeToAircraft() {
+        XCTAssertTrue(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNameInspire1), "\(DJIAircraftModelNameInspire1) gimbal yaw was not relative")
+        XCTAssertTrue(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNameInspire1RAW), "\(DJIAircraftModelNameInspire1RAW) gimbal yaw was not relative")
+        XCTAssertTrue(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNameInspire1Pro), "\(DJIAircraftModelNameInspire1Pro) gimbal yaw was not relative")
 
-        XCTAssertFalse(ControllerUtils.supportsSDKYaw(DJIAircraftModelNamePhantom4), "\(DJIAircraftModelNamePhantom4) supports SDK yaw")
+        XCTAssertTrue(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNamePhantom4), "\(DJIAircraftModelNamePhantom4) gimbal yaw was not relative")
 
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIAircraftModelNamePhantom3Professional), "\(DJIAircraftModelNamePhantom3Professional) didn't support SDK yaw")
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIAircraftModelNamePhantom3Standard), "\(DJIAircraftModelNamePhantom3Standard) didn't support SDK yaw")
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIAircraftModelNamePhantom3Advanced), "\(DJIAircraftModelNamePhantom3Advanced) didn't support SDK yaw")
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIAircraftModelNamePhantom34K), "\(DJIAircraftModelNamePhantom34K) didn't support SDK yaw")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNamePhantom3Professional), "\(DJIAircraftModelNamePhantom3Professional) gimbal yaw was relative")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNamePhantom3Standard), "\(DJIAircraftModelNamePhantom3Standard) gimbal yaw was relative")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNamePhantom3Advanced), "\(DJIAircraftModelNamePhantom3Advanced) gimbal yaw was relative")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIAircraftModelNamePhantom34K), "\(DJIAircraftModelNamePhantom34K) gimbal yaw was relative")
 
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIHandheldModelNameOsmo), "\(DJIHandheldModelNameOsmo) didn't support SDK yaw")
-        XCTAssertTrue(ControllerUtils.supportsSDKYaw(DJIHandheldModelNameOsmoPro), "\(DJIHandheldModelNameOsmoPro) didn't support SDK yaw")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIHandheldModelNameOsmo), "\(DJIHandheldModelNameOsmo) gimbal yaw was relative")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(DJIHandheldModelNameOsmoPro), "\(DJIHandheldModelNameOsmoPro) gimbal yaw was relative")
 
-        XCTAssertFalse(ControllerUtils.supportsSDKYaw(nil), "Missing model supports SDK yaw")
+        XCTAssertFalse(ControllerUtils.gimbalYawIsRelativeToAircraft(nil), "Missing model gimbal yaw was relative")
     }
 
     func testDefaultDisplayIsInMeters() {


### PR DESCRIPTION
This PR adds the ability to tell the gimbal controller that it's yaw is relative to the aircraft yaw.

It will use this relative figure when checking gimbal angle and also in the figure passed out to its delegate (which we show on screen).

It relies on the AC Yaw being fed in (setACYaw) - which is done via the PanoramaController (since that owns the gimbalController instance and the flightController instance).
